### PR TITLE
MIRA and model editing/validating page updates

### DIFF
--- a/epi/modeling/mira.md
+++ b/epi/modeling/mira.md
@@ -76,7 +76,8 @@ python -m pip install -e .[ode,docs]
 
 ## Documentation
 
-Full documentation can be found [here](https://miramodel.readthedocs.io).
+* Full software documentation can be found [here](https://miramodel.readthedocs.io)
+* Training material for working with MIRA template models can be found [here](https://gyorilab.github.io/mira/training_material.html)
 
 ## Example Notebooks
 * Defining multiple model variants using MIRA Templates: [Notebook 1](https://github.com/gyorilab/mira/blob/main/notebooks/metamodel_intro.ipynb)
@@ -94,6 +95,5 @@ Full documentation can be found [here](https://miramodel.readthedocs.io).
 * Benchmarking the efficacy of DKG groundings on a set of COVID EPI Models: 
   [Notebook 11](https://github.com/gyorilab/mira/blob/main/notebooks/hackathon_2023.10/Model%20Comparison.ipynb)
 
-## FAQ
-
 ## Contact Information for Questions
+* Benjamin Gyori: [b.gyori@northeastern.edu](mailto:b.gyori@northeastern.edu)

--- a/epi/modeling/model_edit_valid.md
+++ b/epi/modeling/model_edit_valid.md
@@ -19,17 +19,23 @@ For example, a modeler at a county health department begins with an existing mod
 
 #### *Features Supported*: 
 Users may want to use this workflow to:
-* Leverage an existing model or bring in a model from a paper, 
-* Make structural model modifications, 
-* Find an appropriate set of parameter configurations for updated models they create through structural modifications,
+* Leverage an existing model or bring in a model from a paper
+* Make structural model modifications such as stratification or removal of compartments
+* Find an appropriate set of parameter configurations for updated models they create through structural modifications
 * Check that their models obey some core common-sense rules, using Funman satisfiability checks
 
+#### *Modeling Editing Modalities*
+In the Terarium workbench, users can edit models either by writing Python code in a notebook-like 
+environment or by using the built-in wizard. The wizard offers a simpler, more guided experience with 
+buttons and toggles, making it easy to modify models without writing code. 
+However, it’s less flexible than coding and doesn’t support some advanced edits.
 
 ## Installation and Configuration Instructions
-(please include links to repositories)
+Please refer to the MIRA installation and configuration section to learn how to install MIRA.  
 
 ## Examples
-(please include visuals, screenshots of inputs and outputs, etc.)
+Please refer to the MIRA documentation section to explore training material
+for interacting with MIRA template models using Python code. 
 
 ## FAQ
 


### PR DESCRIPTION
This PR adds a person of contact and a link to training material for editing MIRA template models with Python code in the MIRA documentation. For the model edit and validation documentation, a section on modeling editing modalities and refferal for users to the MIRA documentation section for installation/documentation are added. 